### PR TITLE
add option to define file separators on concat task

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ npm install gulp-asset-transform
 * [implicit tag template references](#implicit_references)
 * [tag templates](#tag_templates)
 * [explicit tags](#explicit_tags)
+* [concat](#concat)
 * [legacy directives](#legacy_directives)
 
 ##Examples
@@ -231,6 +232,28 @@ gulp.task('build', function() {
 			},
 			id2: {
 				tasks:[uglify(), 'concat'],
+			}
+		}))
+		.pipe(gulp.dest('build/client'));
+});
+```
+
+<a name="concat"/>
+### concat
+The concat task can be invoked in basically two ways, by using literal string `'concat:<separator>'` and Asset Transform's helper function `.concat([<filename>[, separator]])`.
+The **filename** argument is optional and if set it will be used to define the output file name. The default value is the name defined in the **at** block.
+The **separator** argument is also optional and is used to define the separator that will join all files contents.
+For instance, in case there are two files named **file_1** and **file_2** and the separator is '`,`' (comma) the output would be `<file_1 contents>,<file_2 contents>`.
+Example:
+```javascript
+gulp.task('build', function() {
+	gulp.src('./src/client/index.html')
+		.pipe(at({
+			id1: {
+                tasks:[uglify(), 'concat:;\n']
+            },
+			id2: {
+				tasks:[uglify(), at.concat('id2.js', ';\n']
 			}
 		}))
 		.pipe(gulp.dest('build/client'));

--- a/index.js
+++ b/index.js
@@ -82,8 +82,14 @@ module.exports = function(config, opts){
 
 }
 
-module.exports.concat = function (customFilename) {
+module.exports.concat = function (customFilename, options) {
+    if (!options) {
+        options = {};
+    } else if (typeof options === 'string') {
+        options = { newLine: options }
+    }
+
     return function (filename) {
-        return gulpConcat(customFilename || filename);
+        return gulpConcat(customFilename || filename, options);
     }
 };

--- a/lib/pipelineStrategies/tasksArrayStrategy.js
+++ b/lib/pipelineStrategies/tasksArrayStrategy.js
@@ -3,8 +3,10 @@ var fs = require('vinyl-fs')
 ;
 
 function getTask(t, filename){
-    if (t == 'concat') {
-        return concat(filename);
+    var newLine = typeof t === 'string' ? t.match(/^concat(?::([\s\S]+))?/) : null;
+
+    if (newLine) {
+        return concat(filename, { newLine: newLine[1] });
     } else if (typeof(t) == 'function') {
         return t(filename);
     } else {

--- a/test/mocha/concat.js
+++ b/test/mocha/concat.js
@@ -10,6 +10,7 @@ var at = require('../../index')
 describe('at.concat', function(){
 
     var indexHtml;
+    var js1Contents, js2Contents;
 
     before(function(){
         var filePath = path.join(__dirname, '../assets/js-only.html');
@@ -19,6 +20,9 @@ describe('at.concat', function(){
             base:     path.dirname(filePath),
             contents: fs.readFileSync(filePath)
         });
+
+        js1Contents = fs.readFileSync(path.join(__dirname, '../assets/js/js1.js'));
+        js2Contents = fs.readFileSync(path.join(__dirname, '../assets/js/js2.js'));
     });
 
     it('should concat files with name defined in the block', function (done) {
@@ -75,6 +79,80 @@ describe('at.concat', function(){
         });
 
         stream.on('end', function() {
+            done();
+        });
+
+        stream.write(indexHtml);
+        stream.end();
+
+    });
+
+    it('should concat files with name and file separator passed as arguments', function (done) {
+
+        var sep = ';';
+
+        var stream = at({
+            js: {
+                tag:'<script src="assets/bundle.js"></script>',
+                tasks: [at.concat('assets/scripts.js', sep)]
+            }
+        });
+
+        var jsContents = '';
+
+        stream.on('data', function(newFile) {
+            var filename = path.basename(newFile.relative);
+            var ext = path.extname(newFile.relative);
+            switch (ext) {
+                case '.js':
+                    expect(filename).to.be.equal('scripts.js');
+                    jsContents += String(newFile._contents);
+                    break;
+                case '.html':
+                    expect(filename).to.be.equal('js-only.html');
+                    break;
+            }
+        });
+
+        stream.on('end', function() {
+            expect(jsContents).to.be.equal(js1Contents + sep + js2Contents);
+            done();
+        });
+
+        stream.write(indexHtml);
+        stream.end();
+
+    });
+
+    it('should concat files with separator passed as \'concat\' suffix', function (done) {
+
+        var sep = ';\n';
+
+        var stream = at({
+            js: {
+                tag:'<script src="assets/bundle.js"></script>',
+                tasks: ['concat:' + sep]
+            }
+        });
+
+        var jsContents = '';
+
+        stream.on('data', function(newFile) {
+            var filename = path.basename(newFile.relative);
+            var ext = path.extname(newFile.relative);
+            switch (ext) {
+                case '.js':
+                    expect(filename).to.be.equal('bundle.js');
+                    jsContents += String(newFile._contents);
+                    break;
+                case '.html':
+                    expect(filename).to.be.equal('js-only.html');
+                    break;
+            }
+        });
+
+        stream.on('end', function() {
+            expect(jsContents).to.be.equal(js1Contents + sep + js2Contents);
             done();
         });
 


### PR DESCRIPTION
This allows users to define the `newLine` option of [gulp-concat](https://www.npmjs.com/package/gulp-concat).
